### PR TITLE
Magic Numbers im CodeMorph und RunButton entfernt

### DIFF
--- a/packages/Presenter-Core.package/PSCodeMorph.class/class/buttonMargin.st
+++ b/packages/Presenter-Core.package/PSCodeMorph.class/class/buttonMargin.st
@@ -1,0 +1,4 @@
+constants
+buttonMargin
+
+	^ 6

--- a/packages/Presenter-Core.package/PSCodeMorph.class/class/monospaceFont.st
+++ b/packages/Presenter-Core.package/PSCodeMorph.class/class/monospaceFont.st
@@ -1,0 +1,4 @@
+constants
+monospaceFont
+
+	^ StrikeFont familyName: 'Courier' pointSize: 12

--- a/packages/Presenter-Core.package/PSCodeMorph.class/class/resultTextOffset.st
+++ b/packages/Presenter-Core.package/PSCodeMorph.class/class/resultTextOffset.st
@@ -1,0 +1,4 @@
+constants
+resultTextOffset
+
+	^ 8 @ 10

--- a/packages/Presenter-Core.package/PSCodeMorph.class/class/separationLineColor.st
+++ b/packages/Presenter-Core.package/PSCodeMorph.class/class/separationLineColor.st
@@ -1,0 +1,4 @@
+constants
+separationLineColor
+
+	^ Color gray: 0.35

--- a/packages/Presenter-Core.package/PSCodeMorph.class/class/separationLineHeight.st
+++ b/packages/Presenter-Core.package/PSCodeMorph.class/class/separationLineHeight.st
@@ -1,0 +1,4 @@
+constants
+separationLineHeight
+
+	^ 1

--- a/packages/Presenter-Core.package/PSCodeMorph.class/instance/addRunButton.st
+++ b/packages/Presenter-Core.package/PSCodeMorph.class/instance/addRunButton.st
@@ -1,12 +1,12 @@
 run button
 addRunButton
+
 	| aRunButton |
-	
 	aRunButton := PSRunButton new
 		action: [self executeCode];
-		fontSize:  self selectionFontSize * self textScale;
+		fontSize: self selectionFontSize * self textScale;
 		yourself.
-	
-	self addMorph: aRunButton;
+	self
+		addMorph: aRunButton;
 		runButton: aRunButton;
-		repositionButton.
+		repositionButton

--- a/packages/Presenter-Core.package/PSCodeMorph.class/instance/drawResultTextOn.withPanelTop..st
+++ b/packages/Presenter-Core.package/PSCodeMorph.class/instance/drawResultTextOn.withPanelTop..st
@@ -1,10 +1,10 @@
 drawing
 drawResultTextOn: aCanvas withPanelTop: aNumber
-	| resultFont |
 
+	| resultFont |
 	resultFont := PSTextMorph defaultTextStyle fontOfSize: (self selectionFontSize * self textScale) rounded.
 	aCanvas
 		drawString: self resultText
-		at: (self left + 8) @ (aNumber + 10) 		"arbitrary offsets (UI)"
+		at: (self left @ aNumber) + self class resultTextOffset
 		font: resultFont
-		color: self resultTextColor.
+		color: self resultTextColor

--- a/packages/Presenter-Core.package/PSCodeMorph.class/instance/drawSeperationLineOn.withPanelTop..st
+++ b/packages/Presenter-Core.package/PSCodeMorph.class/instance/drawSeperationLineOn.withPanelTop..st
@@ -1,7 +1,7 @@
 drawing
 drawSeperationLineOn: aCanvas withPanelTop: aNumber
 
-	aCanvas fillRectangle:
-		(self left @ aNumber corner: 
-			self right @ (aNumber +1))
-		color: (Color gray: 0.35).
+	aCanvas
+		fillRectangle: (self left @ aNumber
+			corner: self right @ (aNumber + self class separationLineHeight))
+		color: self class separationLineColor

--- a/packages/Presenter-Core.package/PSCodeMorph.class/instance/repositionButton.st
+++ b/packages/Presenter-Core.package/PSCodeMorph.class/instance/repositionButton.st
@@ -1,5 +1,8 @@
 run button
 repositionButton
 
+	| margin |
 	self runButton ifNil: [^ self].
-	self runButton position: (self right - self runButton width - 6) @ (self top + 6).		"arbitrary UI offset"
+	margin := self class buttonMargin.
+	self runButton position:
+		(self right - self runButton width - margin) @ (self top + margin)

--- a/packages/Presenter-Core.package/PSCodeMorph.class/instance/useMonospaceFont.st
+++ b/packages/Presenter-Core.package/PSCodeMorph.class/instance/useMonospaceFont.st
@@ -1,8 +1,6 @@
 styling
 useMonospaceFont
-	| attribute font|
-	
-	font := StrikeFont familyName: 'Courier' pointSize: 12.
-	attribute := TextFontReference toFont: font.
-	self addAttribute: attribute.
-		
+
+	| attribute |
+	attribute := TextFontReference toFont: self class monospaceFont.
+	self addAttribute: attribute

--- a/packages/Presenter-Core.package/PSCodeMorph.class/methodProperties.json
+++ b/packages/Presenter-Core.package/PSCodeMorph.class/methodProperties.json
@@ -1,18 +1,22 @@
 {
 	"class" : {
-		 },
+		"buttonMargin" : "rc 7/3/2026 12:28",
+		"monospaceFont" : "rc 7/3/2026 12:17",
+		"resultTextOffset" : "rc 7/3/2026 12:30",
+		"separationLineColor" : "rc 7/3/2026 12:22",
+		"separationLineHeight" : "rc 7/3/2026 12:22" },
 	"instance" : {
-		"addRunButton" : "TK 6/9/2026 15:56",
+		"addRunButton" : "rc 7/3/2026 12:46",
 		"applyUserInterfaceTheme" : "TK 6/10/2026 19:02",
 		"changeFontSize:" : "TK 6/9/2026 15:57",
 		"drawOn:" : "TK 6/9/2026 15:54",
-		"drawResultTextOn:withPanelTop:" : "TK 6/9/2026 15:54",
-		"drawSeperationLineOn:withPanelTop:" : "TK 6/9/2026 15:54",
+		"drawResultTextOn:withPanelTop:" : "rc 7/3/2026 12:41",
+		"drawSeperationLineOn:withPanelTop:" : "rc 7/3/2026 12:37",
 		"executeCode" : "TK 6/9/2026 15:56",
 		"extent:" : "TK 6/9/2026 15:56",
 		"initialize" : "LK 6/30/2026 15:07",
 		"installSyntaxHighlighting" : "TK 5/6/2026 20:36",
-		"repositionButton" : "TK 6/9/2026 15:56",
+		"repositionButton" : "rc 7/3/2026 12:44",
 		"rescale:" : "TK 6/9/2026 15:56",
 		"resultPanelHeight" : "TK 6/29/2026 19:51",
 		"resultText" : "TK 6/9/2026 15:52",
@@ -26,4 +30,4 @@
 		"showResult:" : "TK 6/29/2026 18:20",
 		"textEdited:" : "TK 5/7/2026 10:40",
 		"updateRunButton" : "TK 6/9/2026 15:56",
-		"useMonospaceFont" : "TK 5/7/2026 10:40" } }
+		"useMonospaceFont" : "rc 7/3/2026 12:34" } }

--- a/packages/Presenter-Core.package/PSRunButton.class/class/defaultBackgroundColor.st
+++ b/packages/Presenter-Core.package/PSRunButton.class/class/defaultBackgroundColor.st
@@ -1,0 +1,4 @@
+constants
+defaultBackgroundColor
+
+	^ Color r: 0.10 g: 0.47 b: 0.10

--- a/packages/Presenter-Core.package/PSRunButton.class/class/defaultFontSize.st
+++ b/packages/Presenter-Core.package/PSRunButton.class/class/defaultFontSize.st
@@ -1,0 +1,4 @@
+constants
+defaultFontSize
+
+	^ 5

--- a/packages/Presenter-Core.package/PSRunButton.class/class/extentToFontSizeRatio.st
+++ b/packages/Presenter-Core.package/PSRunButton.class/class/extentToFontSizeRatio.st
@@ -1,0 +1,4 @@
+constants
+extentToFontSizeRatio
+
+	^ 0.75

--- a/packages/Presenter-Core.package/PSRunButton.class/class/hoveredBackgroundColor.st
+++ b/packages/Presenter-Core.package/PSRunButton.class/class/hoveredBackgroundColor.st
@@ -1,0 +1,4 @@
+constants
+hoveredBackgroundColor
+
+	^ Color r: 0.13 g: 0.65 b: 0.13

--- a/packages/Presenter-Core.package/PSRunButton.class/class/runSymbol.st
+++ b/packages/Presenter-Core.package/PSRunButton.class/class/runSymbol.st
@@ -1,0 +1,4 @@
+constants
+runSymbol
+
+	^ '>'

--- a/packages/Presenter-Core.package/PSRunButton.class/class/runSymbolColor.st
+++ b/packages/Presenter-Core.package/PSRunButton.class/class/runSymbolColor.st
@@ -1,0 +1,4 @@
+constants
+runSymbolColor
+
+	^ Color r: 0.67 g: 1.0 b: 0.67

--- a/packages/Presenter-Core.package/PSRunButton.class/instance/drawBackgroundOn..st
+++ b/packages/Presenter-Core.package/PSRunButton.class/instance/drawBackgroundOn..st
@@ -1,9 +1,8 @@
 drawing
 drawBackgroundOn: aCanvas
-	| bgColor |
-	
-	bgColor := self hovered
-		ifTrue:  [Color r: 0.13 g: 0.65 b: 0.13]
-		ifFalse: [Color r: 0.10 g: 0.47 b: 0.10].
-	aCanvas fillRectangle: self bounds color: bgColor.
-	
+
+	| backgroundColor |
+	backgroundColor := self hovered
+		ifTrue: [self class hoveredBackgroundColor]
+		ifFalse: [self class defaultBackgroundColor].
+	aCanvas fillRectangle: self bounds color: backgroundColor

--- a/packages/Presenter-Core.package/PSRunButton.class/instance/drawRunSymbolOn..st
+++ b/packages/Presenter-Core.package/PSRunButton.class/instance/drawRunSymbolOn..st
@@ -1,12 +1,12 @@
 drawing
 drawRunSymbolOn: aCanvas
-	| font xPos yPos |
 
+	| font xPos yPos |
 	font := PSTextMorph defaultTextStyle fontOfSize: self fontSize.
-	xPos := self left + ((self width - (font widthOfString: '>')) // 2).
-	yPos := self top  + ((self height - font height) // 2).
+	xPos := self left + ((self width - (font widthOfString: self class runSymbol)) // 2).
+	yPos := self top + ((self height - font height) // 2).
 	aCanvas
-		drawString: '>'
+		drawString: self class runSymbol
 		at: xPos @ yPos
 		font: font
-		color: (Color r: 0.67 g: 1.0 b: 0.67).
+		color: self class runSymbolColor

--- a/packages/Presenter-Core.package/PSRunButton.class/instance/initialize.st
+++ b/packages/Presenter-Core.package/PSRunButton.class/instance/initialize.st
@@ -2,6 +2,7 @@ initialization
 initialize
 
 	super initialize.
-	self hovered: false;
-		fontSize: 5;
-		borderWidth: 0.
+	self
+		hovered: false;
+		fontSize: self class defaultFontSize;
+		borderWidth: 0

--- a/packages/Presenter-Core.package/PSRunButton.class/instance/updateExtent.st
+++ b/packages/Presenter-Core.package/PSRunButton.class/instance/updateExtent.st
@@ -1,6 +1,6 @@
 sizing
 updateExtent
+
 	| side |
-	
-	side := (self fontSize * 0.75) rounded.
-	self extent: side @ side.
+	side := (self fontSize * self class extentToFontSizeRatio) rounded.
+	self extent: side @ side

--- a/packages/Presenter-Core.package/PSRunButton.class/methodProperties.json
+++ b/packages/Presenter-Core.package/PSRunButton.class/methodProperties.json
@@ -1,21 +1,26 @@
 {
 	"class" : {
-		 },
+		"defaultBackgroundColor" : "rc 7/3/2026 11:48",
+		"defaultFontSize" : "rc 7/3/2026 11:54",
+		"extentToFontSizeRatio" : "rc 7/3/2026 11:56",
+		"hoveredBackgroundColor" : "rc 7/3/2026 11:48",
+		"runSymbol" : "rc 7/3/2026 11:42",
+		"runSymbolColor" : "rc 7/3/2026 11:45" },
 	"instance" : {
 		"action" : "TK 6/9/2026 15:47",
 		"action:" : "TK 6/9/2026 15:47",
-		"drawBackgroundOn:" : "TK 6/9/2026 15:49",
+		"drawBackgroundOn:" : "rc 7/3/2026 12:04",
 		"drawOn:" : "TK 6/9/2026 15:49",
-		"drawRunSymbolOn:" : "TK 6/29/2026 18:56",
+		"drawRunSymbolOn:" : "rc 7/3/2026 12:01",
 		"fontSize" : "TK 6/9/2026 15:47",
 		"fontSize:" : "TK 6/9/2026 15:48",
 		"handlesMouseDown:" : "TK 6/9/2026 15:50",
 		"handlesMouseOver:" : "TK 6/9/2026 15:50",
 		"hovered" : "TK 6/9/2026 15:48",
 		"hovered:" : "TK 6/9/2026 15:48",
-		"initialize" : "TK 6/9/2026 15:50",
+		"initialize" : "rc 7/3/2026 12:06",
 		"mouseDown:" : "JEG 7/2/2026 01:42",
 		"mouseEnter:" : "TK 6/9/2026 15:50",
 		"mouseLeave:" : "TK 6/9/2026 15:50",
 		"prepareToBeSaved" : "JEG 7/2/2026 01:25",
-		"updateExtent" : "TK 6/9/2026 15:51" } }
+		"updateExtent" : "rc 7/3/2026 12:10" } }


### PR DESCRIPTION
im code morph und run button standen ueberall nackte zahlen und rgb werte, teilweise mit kommentaren wie arbitrary offsets daneben
die sind jetzt alle benannte konstanten auf der klassenseite, zb buttonMargin, resultTextOffset und die button farben
die kommentare konnten dadurch weg weil die namen jetzt selbst erklaeren was gemeint ist
werte unveraendert, nur umbenannt und aufgeraeumt