### PR TITLE
Layout Preview Konstanten rausgezogen

### DIFF
--- a/packages/Presenter-Core.package/PSLayoutController.class/class/previewBackgroundColor.st
+++ b/packages/Presenter-Core.package/PSLayoutController.class/class/previewBackgroundColor.st
@@ -1,0 +1,4 @@
+constants
+previewBackgroundColor
+
+	^ Color gray: 0.6

--- a/packages/Presenter-Core.package/PSLayoutController.class/class/previewBorderColor.st
+++ b/packages/Presenter-Core.package/PSLayoutController.class/class/previewBorderColor.st
@@ -1,0 +1,4 @@
+constants
+previewBorderColor
+
+	^ Color gray

--- a/packages/Presenter-Core.package/PSLayoutController.class/class/previewBorderWidth.st
+++ b/packages/Presenter-Core.package/PSLayoutController.class/class/previewBorderWidth.st
@@ -1,0 +1,4 @@
+constants
+previewBorderWidth
+
+	^ 1

--- a/packages/Presenter-Core.package/PSLayoutController.class/class/previewBoxColor.st
+++ b/packages/Presenter-Core.package/PSLayoutController.class/class/previewBoxColor.st
@@ -1,0 +1,4 @@
+constants
+previewBoxColor
+
+	^ Color gray: 0.85

--- a/packages/Presenter-Core.package/PSLayoutController.class/class/previewFormDepth.st
+++ b/packages/Presenter-Core.package/PSLayoutController.class/class/previewFormDepth.st
@@ -1,0 +1,4 @@
+constants
+previewFormDepth
+
+	^ 32

--- a/packages/Presenter-Core.package/PSLayoutController.class/instance/layoutPreviewFor.extent..st
+++ b/packages/Presenter-Core.package/PSLayoutController.class/instance/layoutPreviewFor.extent..st
@@ -2,13 +2,19 @@ layout preview
 layoutPreviewFor: aLayout extent: anExtent
 
 	| form |
-	form := Form extent: anExtent depth: 32.
-	form fillColor: (Color gray: 0.6).
+	form := Form extent: anExtent depth: self class previewFormDepth.
+	form fillColor: self class previewBackgroundColor.
 	aLayout submorphsDo: [:container |
 		container layoutFrame ifNotNil: [:frame | | origin corner box |
 			origin := (frame leftFraction @ frame topFraction) * anExtent.
 			corner := (frame rightFraction @ frame bottomFraction) * anExtent.
 			box := origin asIntegerPoint corner: corner asIntegerPoint.
-			form fill: (box insetBy: 1) fillColor: (Color gray: 0.85).
-			form border: box width: 1 rule: Form over fillColor: Color gray]].
+			form
+				fill: (box insetBy: self class previewBorderWidth)
+				fillColor: self class previewBoxColor.
+			form
+				border: box
+				width: self class previewBorderWidth
+				rule: Form over
+				fillColor: self class previewBorderColor]].
 	^ form

--- a/packages/Presenter-Core.package/PSLayoutController.class/methodProperties.json
+++ b/packages/Presenter-Core.package/PSLayoutController.class/methodProperties.json
@@ -1,12 +1,17 @@
 {
 	"class" : {
-		"for:" : "JEG 7/2/2026 02:52" },
+		"for:" : "JEG 7/2/2026 02:52",
+		"previewBackgroundColor" : "rc 7/3/2026 11:49",
+		"previewBorderColor" : "rc 7/3/2026 12:02",
+		"previewBorderWidth" : "rc 7/3/2026 12:16",
+		"previewBoxColor" : "rc 7/3/2026 11:55",
+		"previewFormDepth" : "rc 7/3/2026 11:47" },
 	"instance" : {
 		"createLayout:from:" : "JEG 7/2/2026 02:54",
 		"createSlideFromLayout:" : "JEG 7/2/2026 02:54",
 		"deleteLayoutNamed:" : "JEG 7/2/2026 02:55",
 		"layoutPreviewFor:" : "JEG 7/2/2026 03:14",
-		"layoutPreviewFor:extent:" : "JEG 7/2/2026 03:15",
+		"layoutPreviewFor:extent:" : "rc 7/3/2026 12:27",
 		"layoutThumbnailFor:" : "JEG 7/2/2026 03:14",
 		"openDeleteLayoutChooser" : "JEG 7/2/2026 03:12",
 		"openLayoutMenu" : "JEG 7/2/2026 03:05",

--- a/packages/Presenter-Core.package/PSLayoutMenuItem.class/class/previewBorderWidth.st
+++ b/packages/Presenter-Core.package/PSLayoutMenuItem.class/class/previewBorderWidth.st
@@ -1,0 +1,4 @@
+constants
+previewBorderWidth
+
+	^ 1

--- a/packages/Presenter-Core.package/PSLayoutMenuItem.class/class/previewOffset.st
+++ b/packages/Presenter-Core.package/PSLayoutMenuItem.class/class/previewOffset.st
@@ -1,0 +1,4 @@
+constants
+previewOffset
+
+	^ 8 @ 0

--- a/packages/Presenter-Core.package/PSLayoutMenuItem.class/instance/showPreview.st
+++ b/packages/Presenter-Core.package/PSLayoutMenuItem.class/instance/showPreview.st
@@ -1,14 +1,14 @@
 private
 showPreview
+
 	| form image |
-	
 	self hidePreview.
 	form := self target layoutPreviewFor: self layout.
 	image := ImageMorph new
 		image: form;
-		borderWidth: 1;
+		borderWidth: self class previewBorderWidth;
 		borderColor: Color gray;
-		position: self boundsInWorld topRight + (8 @ 0);
+		position: self boundsInWorld topRight + self class previewOffset;
 		yourself.
 	self previewMorph: image.
 	self world ifNotNil: [:aWorld | aWorld addMorphFront: self previewMorph]

--- a/packages/Presenter-Core.package/PSLayoutMenuItem.class/methodProperties.json
+++ b/packages/Presenter-Core.package/PSLayoutMenuItem.class/methodProperties.json
@@ -1,6 +1,7 @@
 {
 	"class" : {
-		 },
+		"previewBorderWidth" : "rc 7/3/2026 12:38",
+		"previewOffset" : "rc 7/3/2026 12:40" },
 	"instance" : {
 		"delete" : "LK 6/9/2026 19:47",
 		"handlesMouseOver:" : "LK 6/9/2026 19:53",
@@ -12,4 +13,4 @@
 		"mouseLeave:" : "LK 6/9/2026 19:53",
 		"previewMorph" : "TK 6/29/2026 18:48",
 		"previewMorph:" : "TK 6/29/2026 18:49",
-		"showPreview" : "TK 6/29/2026 18:52" } }
+		"showPreview" : "rc 7/3/2026 12:43" } }


### PR DESCRIPTION
im layout preview rendering standen noch einige nackte zahlen und farben rum, zb depth 32 und die beiden grautone
die liegen jetzt als benannte konstanten auf der klassenseite vom controller, dann sieht man direkt was was ist
beim menu item das gleiche fuer border width und offset vom preview