### PR TITLE
fixed undo bug with slide deletion

### DIFF
--- a/packages/Presenter-Core.package/PSPresentationTool.class/instance/updateSlideMiniatureCompletelyAt..st
+++ b/packages/Presenter-Core.package/PSPresentationTool.class/instance/updateSlideMiniatureCompletelyAt..st
@@ -1,7 +1,8 @@
 slide miniatures
 updateSlideMiniatureCompletelyAt: aNumber
- 
-	self selectSlideAt: aNumber.
-	self currentSlide changed.
-	self currentSlide world displayWorldSafely.
-	self updateCurrentMiniature
+
+	| slide |
+	slide := self presentation slideAt: aNumber.
+	slide changed.
+	slide world ifNotNil: [:world | world displayWorldSafely].
+	(self miniatureOf: slide) updateImage

--- a/packages/Presenter-Core.package/PSPresentationTool.class/methodProperties.json
+++ b/packages/Presenter-Core.package/PSPresentationTool.class/methodProperties.json
@@ -190,7 +190,7 @@
 		"updateCurrentMiniature" : "LB 6/29/2018 17:21",
 		"updatePresentation:" : "JEG 6/15/2026 14:39",
 		"updateSelection:" : "rc 7/3/2026 12:14",
-		"updateSlideMiniatureCompletelyAt:" : "JEG 6/17/2026 03:13",
+		"updateSlideMiniatureCompletelyAt:" : "JEG 7/4/2026 22:09",
 		"updateSlideMiniatures" : "LB 6/29/2018 17:08",
 		"updateSlideMiniaturesCompletely" : "jb 7/26/2019 12:05",
 		"updateUndoRedoButtons" : "JEG 7/1/2026 18:52",


### PR DESCRIPTION
fixed undo bug with slide deletion (when undoing the deletion of a slide, the system would cycle through all the created slides in a loop. Changed the method updateSlideMiniatureCompletelyAt: so that it does not change the current slide selection to every slide)