### PR TITLE
added and edited class comments

### DIFF
--- a/packages/Presenter-Core.package/PSChangeMorphPropertyCommand.class/README.md
+++ b/packages/Presenter-Core.package/PSChangeMorphPropertyCommand.class/README.md
@@ -1,0 +1,23 @@
+A PSChangeMorphPropertyCommand represents an undoable change of one property on an object.
+
+Instance Variables
+	target:			<Object>
+	getterSelector:	<Symbol>
+	setterSelector:	<Symbol>
+	oldValue:		<Object>
+	newValue:		<Object>
+
+target
+	- The object whose property is changed
+
+getterSelector
+	- The selector used to read the property's current value before executing the command
+
+setterSelector
+	- The selector used to apply the old or new property value
+
+oldValue
+	- The value of the property before the command was executed
+
+newValue
+	- The value that should be applied when the command is executed

--- a/packages/Presenter-Core.package/PSChangeMorphPropertyCommand.class/properties.json
+++ b/packages/Presenter-Core.package/PSChangeMorphPropertyCommand.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "",
+	"commentStamp" : "JEG 7/5/2026 17:57",
 	"instvars" : [
 		"target",
 		"getterSelector",

--- a/packages/Presenter-Core.package/PSContentCreationController.class/README.md
+++ b/packages/Presenter-Core.package/PSContentCreationController.class/README.md
@@ -1,0 +1,8 @@
+A PSContentCreationController creates new slide content for a PSPresentationTool.
+It centralizes creation of text fields, code fields, image fields and basic shapes.
+
+Instance Variables
+	tool:	<PSPresentationTool>
+
+tool
+	- The presentation tool whose current slide receives the created content

--- a/packages/Presenter-Core.package/PSContentCreationController.class/properties.json
+++ b/packages/Presenter-Core.package/PSContentCreationController.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "",
+	"commentStamp" : "JEG 7/5/2026 17:59",
 	"instvars" : [
 		"tool" ],
 	"name" : "PSContentCreationController",

--- a/packages/Presenter-Core.package/PSLayoutController.class/README.md
+++ b/packages/Presenter-Core.package/PSLayoutController.class/README.md
@@ -1,0 +1,8 @@
+A PSLayoutController manages slide layouts for a PSPresentationTool.
+It creates slides from layouts, saves slides as layouts, renames layouts, deletes layouts and opens the layout chooser menus.
+
+Instance Variables
+	tool:	<PSPresentationTool>
+
+tool
+	- The presentation tool whose presentation layouts are managed

--- a/packages/Presenter-Core.package/PSLayoutController.class/properties.json
+++ b/packages/Presenter-Core.package/PSLayoutController.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "",
+	"commentStamp" : "JEG 7/5/2026 18:01",
 	"instvars" : [
 		"tool" ],
 	"name" : "PSLayoutController",

--- a/packages/Presenter-Core.package/PSLayoutMenuItem.class/README.md
+++ b/packages/Presenter-Core.package/PSLayoutMenuItem.class/README.md
@@ -1,11 +1,12 @@
-A PSLayoutMenuItem is xxxxxxxxx.
+A PSLayoutMenuItem is a menu item for choosing a slide layout.
+It can show and hide a small preview morph for the represented layout while the item is hovered.
 
 Instance Variables
-	layout:		<Object>
-	previewMorph:		<Object>
+	layout:			<PSSlideLayout>
+	previewMorph:	<Morph>
 
 layout
-	- the layout that is hovered over as an option for a slide
+	- the layout that is represented by this menu item
 
 previewMorph
-	- the mini preview that is shown, when choosing a layout for a slide
+	- the mini preview that is shown when choosing a layout for a slide

--- a/packages/Presenter-Core.package/PSLayoutMenuItem.class/properties.json
+++ b/packages/Presenter-Core.package/PSLayoutMenuItem.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "TK 6/29/2026 20:32",
+	"commentStamp" : "JEG 7/5/2026 18:04",
 	"instvars" : [
 		"layout",
 		"previewMorph" ],

--- a/packages/Presenter-Core.package/PSPNGExportController.class/README.md
+++ b/packages/Presenter-Core.package/PSPNGExportController.class/README.md
@@ -1,0 +1,8 @@
+A PSPNGExportController exports slides of a PSPresentationTool as PNG files.
+It can export all slides or selected slide ranges into an export directory.
+
+Instance Variables
+	tool:	<PSPresentationTool>
+
+tool
+	- The presentation tool whose slides are exported

--- a/packages/Presenter-Core.package/PSPNGExportController.class/properties.json
+++ b/packages/Presenter-Core.package/PSPNGExportController.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "",
+	"commentStamp" : "JEG 7/5/2026 18:02",
 	"instvars" : [
 		"tool" ],
 	"name" : "PSPNGExportController",

--- a/packages/Presenter-Core.package/PSPresentationSaveLoading.class/README.md
+++ b/packages/Presenter-Core.package/PSPresentationSaveLoading.class/README.md
@@ -1,7 +1,8 @@
-A PSPresentationSaveLoading is an abstract class that declares the default directory names for saving and .
+A PSPresentationSaveLoading is an abstract superclass for presentation saving and loading.
+It provides shared directory and file naming conventions used by PSPresentationSaver and PSPresentationLoader.
 
 Instance Variables
-	presentation:		<PSPresentation>
+	presentation:	<PSPresentation>
 
 presentation
-	- the presentation to perform operation on
+	- The presentation to save or load into

--- a/packages/Presenter-Core.package/PSPresentationSaveLoading.class/properties.json
+++ b/packages/Presenter-Core.package/PSPresentationSaveLoading.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "TK 6/29/2026 17:44",
+	"commentStamp" : "JEG 7/5/2026 18:05",
 	"instvars" : [
 		"presentation" ],
 	"name" : "PSPresentationSaveLoading",

--- a/packages/Presenter-Core.package/PSScriptingTool.class/README.md
+++ b/packages/Presenter-Core.package/PSScriptingTool.class/README.md
@@ -1,7 +1,5 @@
-A PSScriptingTool lets a user define custom scripts that are then executed by
-a aPSContentContainer. It should be opened using openFor: aMorph.
-The script is checked for syntax upon saving and put into the receiver's
-properties.
+A PSScriptingTool lets a user define custom scripts that are then executed by a PSContentContainer. 
+It is opened for a receiver morph, lets the user edit script code, checks syntax on saving and stores the scripts in the receiver's properties.
 
 Instance Variables
 	code:		<Text>
@@ -11,10 +9,16 @@ Instance Variables
 	selectedMethod:		<Symbol>
 
 code
-	- The scipt is put into code upon saving.
+	- The script source currently edited by the user
 
 codePane
-	- The widget where the user is able to insert the script. Needed to hide/unhide
-		it when selecting the method.
+	- The text widget in which the user edits the script
+
 receiver
-	- The morph to save the script in
+	- The morph whose scripts are edited
+
+selectedIndex
+	- The index of the currently selected script/action entry
+
+selectedMethod
+	- The selector of the script/action currently selected for editing

--- a/packages/Presenter-Core.package/PSScriptingTool.class/properties.json
+++ b/packages/Presenter-Core.package/PSScriptingTool.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "VO 7/25/2019 15:49",
+	"commentStamp" : "JEG 7/5/2026 18:09",
 	"instvars" : [
 		"receiver",
 		"code",

--- a/packages/Presenter-Core.package/PSSlide.class/README.md
+++ b/packages/Presenter-Core.package/PSSlide.class/README.md
@@ -1,11 +1,12 @@
 A PSSlide is a Morph to place content on.
-Every morph put on a PSSlide is put into a PSContentContainer.
-Whenever it is resized, all the contents are rescaled with a fixed width-to-height ratio.
+Every morph put on a PSSlide is wrapped in a PSContentContainer. The slide also stores visibility and presentation ownership information. Whenever it is resized, all the contents are rescaled with a fixed width-to-height ratio.
 
 Instance Variables
 	isHidden: <Boolean>
 	presentation: <PSPresentation>
 	
+isHidden
+	- Indicates whether this slide should be skipped in presentation mode
+
 presentation
-	- the presentation the slide is currently on. Is set to nil if the slide was 
-		moved out via its PSMiniature
+	- The presentation this slide belongs to

--- a/packages/Presenter-Core.package/PSSlide.class/properties.json
+++ b/packages/Presenter-Core.package/PSSlide.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "VO 7/25/2019 15:14",
+	"commentStamp" : "JEG 7/5/2026 18:12",
 	"instvars" : [
 		"isHidden",
 		"presentation" ],

--- a/packages/Presenter-Tests.package/PSCommandHistoryTest.class/README.md
+++ b/packages/Presenter-Tests.package/PSCommandHistoryTest.class/README.md
@@ -1,0 +1,12 @@
+A PSCommandHistoryTest tests undo and redo stack behavior of PSCommandHistory.
+It uses test commands that append their execution to a log.
+
+Instance Variables
+	history:	<PSCommandHistory>
+	log:		<OrderedCollection>
+
+history
+	- The command history tested by each test
+
+log
+	- Records executed and unexecuted test commands

--- a/packages/Presenter-Tests.package/PSCommandHistoryTest.class/properties.json
+++ b/packages/Presenter-Tests.package/PSCommandHistoryTest.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "",
+	"commentStamp" : "JEG 7/5/2026 18:22",
 	"instvars" : [
 		"history",
 		"log" ],

--- a/packages/Presenter-Tests.package/PSInteractableMorphTest.class/README.md
+++ b/packages/Presenter-Tests.package/PSInteractableMorphTest.class/README.md
@@ -1,0 +1,16 @@
+A PSInteractableMorphTest is a shared superclass for tests of morph interaction on a slide.
+It stores a morph, its content container and whether an interaction was received.
+
+Instance Variables
+	container:		<PSContentContainer>
+	interacted:		<Boolean>
+	morph:			<Morph>
+
+container
+	- The content container holding the tested morph
+
+interacted
+	- Indicates whether the tested interaction was triggered
+
+morph
+	- The morph used as the interaction test subject

--- a/packages/Presenter-Tests.package/PSInteractableMorphTest.class/properties.json
+++ b/packages/Presenter-Tests.package/PSInteractableMorphTest.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "",
+	"commentStamp" : "JEG 7/5/2026 18:21",
 	"instvars" : [
 		"morph",
 		"interacted",

--- a/packages/Presenter-Tests.package/PSMockDictionary.class/README.md
+++ b/packages/Presenter-Tests.package/PSMockDictionary.class/README.md
@@ -1,0 +1,2 @@
+A PSMockDictionary is a Dictionary test double used in loading tests.
+It can stand in for a filed-in dictionary object without requiring an actual stream.

--- a/packages/Presenter-Tests.package/PSMockDictionary.class/properties.json
+++ b/packages/Presenter-Tests.package/PSMockDictionary.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "",
+	"commentStamp" : "JEG 7/5/2026 18:27",
 	"instvars" : [
 		 ],
 	"name" : "PSMockDictionary",

--- a/packages/Presenter-Tests.package/PSOnSlideTest.class/README.md
+++ b/packages/Presenter-Tests.package/PSOnSlideTest.class/README.md
@@ -1,0 +1,12 @@
+A PSOnSlideTest is a shared superclass for tests that need a slide inside a slide container.
+It provides a prepared PSSlide and PSSlideContainer for interaction and content tests.
+
+Instance Variables
+	slide:	  <PSSlide>
+	slideContainer:	<PSSlideContainer>
+
+slide
+	- The slide used as the test subject
+
+slideContainer
+	- The container displaying the test slide

--- a/packages/Presenter-Tests.package/PSOnSlideTest.class/properties.json
+++ b/packages/Presenter-Tests.package/PSOnSlideTest.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "",
+	"commentStamp" : "JEG 7/5/2026 18:18",
 	"instvars" : [
 		"slide",
 		"slideContainer" ],

--- a/packages/Presenter-Tests.package/PSPresentationSectionModelTest.class/README.md
+++ b/packages/Presenter-Tests.package/PSPresentationSectionModelTest.class/README.md
@@ -1,0 +1,8 @@
+A PSPresentationSectionModelTest tests the section model behavior of PSPresentation.
+It covers creating, deleting, moving, nesting, collapsing and querying slide sections without going through the presentation tool UI.
+
+Instance Variables
+	presentation:	<PSPresentation>
+
+presentation
+	- The presentation whose section model behavior is tested

--- a/packages/Presenter-Tests.package/PSPresentationSectionModelTest.class/properties.json
+++ b/packages/Presenter-Tests.package/PSPresentationSectionModelTest.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "",
+	"commentStamp" : "JEG 7/5/2026 18:33",
 	"instvars" : [
 		"presentation" ],
 	"name" : "PSPresentationSectionModelTest",

--- a/packages/Presenter-Tests.package/PSPresentationToolTest.class/README.md
+++ b/packages/Presenter-Tests.package/PSPresentationToolTest.class/README.md
@@ -1,0 +1,2 @@
+A PSPresentationToolTest tests the main user-facing behavior of PSPresentationTool.
+It covers presentation setup, slide operations, menus, shortcuts, dirty-state handling and other tool-level workflows.

--- a/packages/Presenter-Tests.package/PSPresentationToolTest.class/properties.json
+++ b/packages/Presenter-Tests.package/PSPresentationToolTest.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "",
+	"commentStamp" : "JEG 7/5/2026 18:32",
 	"instvars" : [
 		 ],
 	"name" : "PSPresentationToolTest",

--- a/packages/Presenter-Tests.package/PSPresentationToolTestCase.class/README.md
+++ b/packages/Presenter-Tests.package/PSPresentationToolTestCase.class/README.md
@@ -1,0 +1,16 @@
+A PSPresentationToolTestCase is a shared superclass for tests that need a PSPresentationTool opened in a test world.
+It stores the opened window and restores global display preferences after each test.
+
+Instance Variables
+	window:				<SystemWindow>
+	fullScreenMode:		<Boolean>
+	logoPreference:		<Boolean>
+
+window
+	- The window containing the PSPresentationTool used by the test
+
+fullScreenMode
+	- The full-screen state before the test started
+
+logoPreference
+	- The logo visibility preference before the test started

--- a/packages/Presenter-Tests.package/PSPresentationToolTestCase.class/properties.json
+++ b/packages/Presenter-Tests.package/PSPresentationToolTestCase.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "",
+	"commentStamp" : "JEG 7/5/2026 18:17",
 	"instvars" : [
 		"window",
 		"fullScreenMode",

--- a/packages/Presenter-Tests.package/PSSlideAndMorphTest.class/README.md
+++ b/packages/Presenter-Tests.package/PSSlideAndMorphTest.class/README.md
@@ -1,0 +1,7 @@
+A PSSlideAndMorphTest is a shared superclass for tests that need a slide and a morph on that slide.
+
+Instance Variables
+	morph:	<Morph>
+
+morph
+	- The morph used as test content on the slide

--- a/packages/Presenter-Tests.package/PSSlideAndMorphTest.class/properties.json
+++ b/packages/Presenter-Tests.package/PSSlideAndMorphTest.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "",
+	"commentStamp" : "JEG 7/5/2026 18:23",
 	"instvars" : [
 		"morph" ],
 	"name" : "PSSlideAndMorphTest",

--- a/packages/Presenter-Tests.package/PSTestCommand.class/README.md
+++ b/packages/Presenter-Tests.package/PSTestCommand.class/README.md
@@ -1,0 +1,12 @@
+A PSTestCommand is a simple command double used by command history tests.
+It records execute and unexecute calls in a shared log.
+
+Instance Variables
+	log:	<OrderedCollection>
+	name:	<String>
+
+log
+	- The collection receiving execution entries
+
+name
+	- The name used to identify this command in the log

--- a/packages/Presenter-Tests.package/PSTestCommand.class/properties.json
+++ b/packages/Presenter-Tests.package/PSTestCommand.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "",
+	"commentStamp" : "JEG 7/5/2026 18:23",
 	"instvars" : [
 		"log",
 		"name" ],


### PR DESCRIPTION
added and edited missing class comments and descriptions of instance variables for all classes in Presenter Core and shared superclasses in Presenter Tests (figured the standard test classes are descriptive enough as they are and class comments would only make them more annoying to maintain)